### PR TITLE
PyQt6 support

### DIFF
--- a/src/inspector.py
+++ b/src/inspector.py
@@ -25,7 +25,10 @@ class Inspector(QDockWidget):
         super().__init__(title, parent)
         self.setObjectName(ADDON)
         self.setAllowedAreas(
-            Qt.DockWidgetArea.LeftDockWidgetArea|Qt.DockWidgetArea.RightDockWidgetArea|Qt.DockWidgetArea.BottomDockWidgetArea)
+              Qt.DockWidgetArea.LeftDockWidgetArea
+            | Qt.DockWidgetArea.RightDockWidgetArea
+            | Qt.DockWidgetArea.BottomDockWidgetArea
+        )
         self.toggleViewAction().setText('Toggle Inspector')
         # make the title bar thinner
         self.setStyleSheet(QDOCKWIDGET_STYLE)
@@ -84,11 +87,8 @@ def check_qt_version():
     """
     setInspectedPage, setDevToolsPageはQt5.11以降対応なのでチェックする
     """
-    qt_ver = QT_VERSION_STR.split('.')
-    if int(qt_ver[1]) < 11:
-        return False
-    else:
-        return True
+    qt_major_ver, qt_minor_ver = [int(string) for string in QT_VERSION_STR.split('.')][:2]
+    return (qt_major_ver == 5 and qt_minor_ver >= 11) or qt_major_ver == 6
 
 
 def main():

--- a/src/inspector.py
+++ b/src/inspector.py
@@ -25,7 +25,7 @@ class Inspector(QDockWidget):
         super().__init__(title, parent)
         self.setObjectName(ADDON)
         self.setAllowedAreas(
-            Qt.LeftDockWidgetArea|Qt.RightDockWidgetArea|Qt.BottomDockWidgetArea)
+            Qt.DockWidgetArea.LeftDockWidgetArea|Qt.DockWidgetArea.RightDockWidgetArea|Qt.DockWidgetArea.BottomDockWidgetArea)
         self.toggleViewAction().setText('Toggle Inspector')
         # make the title bar thinner
         self.setStyleSheet(QDOCKWIDGET_STYLE)
@@ -52,9 +52,9 @@ class Inspector(QDockWidget):
 
         # font size
         ws = self.web.settings()
-        ws.setFontSize(QWebEngineSettings.MinimumFontSize, FONT_SIZE)
-        ws.setFontSize(QWebEngineSettings.MinimumLogicalFontSize, FONT_SIZE)
-        ws.setFontSize(QWebEngineSettings.DefaultFontSize, FONT_SIZE)
+        ws.setFontSize(QWebEngineSettings.FontSize.MinimumFontSize, FONT_SIZE)
+        ws.setFontSize(QWebEngineSettings.FontSize.MinimumLogicalFontSize, FONT_SIZE)
+        ws.setFontSize(QWebEngineSettings.FontSize.DefaultFontSize, FONT_SIZE)
 
         # "Uncaught ReferenceError: qt is not defined"を防ぐために
         # AnkiWebViewと同じwebChannelを使う
@@ -96,7 +96,7 @@ def main():
         return
 
     inspector = Inspector('', mw)
-    mw.addDockWidget(Qt.RightDockWidgetArea, inspector)
+    mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, inspector)
 
 
 main()


### PR DESCRIPTION
This fixes two minor issues which caused incompatibility with PyQt6 and closes https://github.com/hikaru-y/anki21-addon-ankiwebview-inspector/issues/6.

## Changes
- Use scoped access to enum values (With PyQt 6, this is the only way Qt enums can be accessed.)
- `check_qt_version` refactored to support PyQt5 > 11 and PyQt6

Initial testing looks good.